### PR TITLE
Remove AWS SDK dependency since `instanceof` is unreliable.

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -2,8 +2,7 @@
 'use strict';
 
 var _ = require('lodash'),
-	crypto = require('crypto'),
-	AWS = require('aws-sdk');
+	crypto = require('crypto');
 
 /**
  * @constructor
@@ -18,7 +17,7 @@ function MultipartUpload(s3, options) {
 	}
 
 	// Safety first
-	if (s3 instanceof AWS.S3 === false) {
+	if (!s3 || !_.isFunction(s3.createMultipartUpload)) {
 		throw new TypeError();
 	}
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var _ = require('lodash'),
-	AWS = require('aws-sdk'),
 	Stream = require('stream'),
 	util = require('util');
 
@@ -16,7 +15,8 @@ function S3ReadStream(client, options, streamOptions) {
 	if (this instanceof S3ReadStream === false) {
 		return new S3ReadStream(client, options, streamOptions);
 	}
-	if (client instanceof AWS.S3 === false) {
+
+	if (!client || !_.isFunction(client.getObject)) {
 		throw new TypeError();
 	}
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"aws-sdk": "*",
 		"lodash": "*"
+	},
+	"peerDependencies": {
+		"aws-sdk": "*"
 	},
 	"devDependencies": {
 		"eslint": "*",

--- a/test/spec/multipart.js
+++ b/test/spec/multipart.js
@@ -2,18 +2,18 @@
 'use strict';
 
 var _ = require('lodash'),
-	AWS = require('aws-sdk'),
 	MultipartUpload = require('multipart');
 
 describe('MultipartUpload', function() {
 
 	beforeEach(function() {
 		this.sandbox = sinon.sandbox.create();
-		this.s3 = sinon.createStubInstance(AWS.S3);
-		this.s3.uploadPart = sinon.stub();
-		this.s3.abortMultipartUpload = sinon.stub();
-		this.s3.completeMultipartUpload = sinon.stub();
-		this.s3.createMultipartUpload = sinon.stub();
+		this.s3 = {
+			uploadPart: this.sandbox.stub(),
+			abortMultipartUpload: this.sandbox.stub(),
+			completeMultipartUpload: this.sandbox.stub(),
+			createMultipartUpload: this.sandbox.stub()
+		};
 	});
 
 	afterEach(function() {

--- a/test/spec/read.js
+++ b/test/spec/read.js
@@ -3,7 +3,6 @@
 
 var _ = require('lodash'),
 	crypto = require('crypto'),
-	AWS = require('aws-sdk'),
 	S3ReadStream = require('read'),
 	Stream = require('stream'),
 	EventEmitter = require('events').EventEmitter;
@@ -51,8 +50,7 @@ describe('S3ReadStream', function() {
 
 	beforeEach(function() {
 		this.sandbox = sinon.sandbox.create();
-		this.s3 = sinon.createStubInstance(AWS.S3);
-		this.s3.getObject = sinon.stub();
+		this.s3 = { getObject: this.sandbox.stub() };
 		this.request = new EventEmitter();
 		this.s3.getObject.returns(this.request);
 		this.source = new Stream.PassThrough();

--- a/test/spec/write.js
+++ b/test/spec/write.js
@@ -2,14 +2,13 @@
 'use strict';
 
 var _ = require('lodash'),
-	AWS = require('aws-sdk'),
 	S3WriteStream = require('write');
 
 describe('S3WriteStream', function() {
 
 	beforeEach(function() {
 		this.sandbox = sinon.sandbox.create();
-		this.s3 = sinon.createStubInstance(AWS.S3);
+		this.s3 = { createMultipartUpload: this.sandbox.stub() };
 	});
 
 	afterEach(function() {


### PR DESCRIPTION
When two different versions of the SDK are installed and required node marks them as different, so instead just duck type it. This also conveniently makes testing a little easier too.
