### PR TITLE
Support older node versions via `readable-stream`/`es6-promise`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
 - '0.11'
+- '0.10'
+- '0.8'
+before_install:
+  - npm install -g "npm@>=1.4.6"
 after_success:
 - npm install coveralls
 - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 Amazon makes it a giant pain to do anything stream-like when it comes to S3 (given the general restriction that every request needs a `Content-Length` header). We provide native stream classes (both `Readable` and `Writable`) that wrap `aws-sdk` S3 requests and responses to make your life easier.
 
-IMPORTANT: You must be using `node >= 0.11` since we use newer stream functionality.
+IMPORTANT: This library uses the `streams3` API. In order to provide compatibility with older versions of node we make use of [readable-stream]. This is unlikely to have any effect on your code but has not yet been well tested.
+
+If you are using `node 0.8` you must ensure your version of `npm` is at least `1.4.6`.
 
 Features:
  * Native read streams,
@@ -73,3 +75,5 @@ Existing frameworks:
  * s3-download-stream (only does downloads, downloads are streamed by S3 part, not by individual buffer chunks)
  * streaming-s3 (overall terrible API; no actual streams)
  * create-s3-object-write-stream (probably one of the better ones)
+
+[readable-stream]: http://www.nearform.com/nodecrunch/dont-use-nodes-core-stream-module/

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -2,7 +2,8 @@
 'use strict';
 
 var _ = require('lodash'),
-	crypto = require('crypto');
+	crypto = require('crypto'),
+	Promise = require('es6-promise').Promise;
 
 /**
  * @constructor

--- a/lib/read.js
+++ b/lib/read.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var _ = require('lodash'),
-	Stream = require('stream'),
+	Stream = require('readable-stream'),
 	util = require('util');
 
 /**

--- a/lib/write.js
+++ b/lib/write.js
@@ -3,7 +3,7 @@
 
 var _ = require('lodash'),
 	MultipartUpload = require('./multipart'),
-	Stream = require('stream'),
+	Stream = require('readable-stream'),
 	util = require('util');
 
 /**
@@ -31,16 +31,10 @@ function S3WriteStream(client, options, streamOptions) {
 
 	Stream.Writable.call(this, streamOptions);
 	this.upload = new MultipartUpload(client, options);
-	this._ending = false;
 
 	// Start by buffering data since AWS requires at least 5 MB
 	// of buffered chunks in one go.
 	this.cork();
-
-	// If an error occurs then abort the upload.
-	//this.once('error', function error() {
-	//	upload.abort();
-	//});
 }
 util.inherits(S3WriteStream, Stream.Writable);
 S3WriteStream.lowWaterMark = 5242880;
@@ -49,13 +43,53 @@ S3WriteStream.lowWaterMark = 5242880;
  * We override the normal end call to mark when the EOS is
  * actually occuring. This is necessary since Stream.Writable
  * provides no `_flush` method that actually works.
+ *
+ * @param {Buffer} data Data to write.
+ * @param {String} encoding Encoding of data.
+ * @param {Function} cb Callback when write is done.
+ * @returns {void}
+ *
  * @see Stream.Writable.ending
- * @returns {Undefined} Something.
  */
-S3WriteStream.prototype.end = function end() {
-	// Mark the stream as ending and continue on as normal.
-	this._ending = true;
-	return Stream.Writable.prototype.end.apply(this, arguments);
+S3WriteStream.prototype.end = function end(data, encoding, cb) {
+	var self = this;
+
+	if (_.isFunction(data)) {
+		cb = data;
+		data = null;
+		encoding = null;
+	} else if (_.isFunction(encoding)) {
+		cb = encoding;
+		encoding = null;
+	}
+
+	function finalize() {
+		self.upload.finish().then(function finished() {
+			// Finally we can actually trigger the upstream end.
+			Stream.Writable.prototype.end.call(self, cb);
+		}).catch(function errored(err) {
+			// We failed; emulate how the writable triggers errors
+			self._writableState.errorEmitted = true;
+			cb(err);
+			self.emit('error', err);
+		});
+	}
+
+	// If we have data to write, then it's easy we just chain our _flush
+	// to the end of the write call, otherwise we write some dummy buffer
+	// with nothing in it which will be called after the last other peice
+	// of data has been finished writing.
+	if (data) {
+		self.write(data, encoding, finalize);
+	} else {
+		self.write(new Buffer(0), finalize);
+	}
+
+	// Uncork and flush everything
+	if (self._writableState.corked) {
+		self._writableState.corked = 1;
+		self.uncork();
+	}
 };
 
 /**
@@ -69,7 +103,7 @@ S3WriteStream.prototype.end = function end() {
 S3WriteStream.prototype.write = function write() {
 	// Write normally; since we're corked this isn't going to
 	// do anything other than add data to the buffer.
-	Stream.Writable.prototype.write.apply(this, arguments);
+	var result = Stream.Writable.prototype.write.apply(this, arguments);
 
 	// Check to see if we've past the upload threshold and if
 	// so `uncork` so we can batch write everything at once. Since
@@ -79,32 +113,24 @@ S3WriteStream.prototype.write = function write() {
 		this.uncork();
 		this.cork();
 	}
+
+	return result;
 };
 
 S3WriteStream.prototype._part = function _part(buffer, callback) {
-
-	var part = this.upload.uploadPart(buffer);
-
-	// Note that the stream is going down. This means that during
-	// the this call to `uploadPart` the last part will have been
-	// added to `parts` and thus it will be safe to finalize the
-	// multi- part upload.
-	if (this._ending) {
-		this.upload.finish();
-	}
-
-	return part.then(_.partial(callback, null), callback);
-
+	return this.upload.uploadPart(buffer)
+		.then(_.partial(callback, null), callback);
 };
 
 /**
- * @param {Array} chunks Array of internal node write stream chunks.
+ * @param {Array} buffers Array of internal node write stream chunks.
  * @param {Function} callback Called on completion of the write.
  * @returns {Promise<Part>} The part resulting from the chunks.
  * @see Stream.Writable._writev
  */
-S3WriteStream.prototype._writev = function _writev(chunks, callback) {
-	var data = Buffer.concat(_.pluck(chunks, 'chunk'), this._writableState.length);
+S3WriteStream.prototype._writev = function _writev(buffers, callback) {
+	var chunks = _.pluck(buffers, 'chunk'),
+		data = Buffer.concat(chunks, this._writableState.length);
 	return this._part(data, callback);
 };
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
 		"coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100"
 	},
 	"dependencies": {
-		"lodash": "*"
+		"lodash": "^2.4.1",
+		"readable-stream": "^1.1.13",
+		"es6-promise": "^2.0.0"
 	},
 	"peerDependencies": {
 		"aws-sdk": "*"

--- a/test/spec/multipart.js
+++ b/test/spec/multipart.js
@@ -2,7 +2,8 @@
 'use strict';
 
 var _ = require('lodash'),
-	MultipartUpload = require('multipart');
+	MultipartUpload = require('multipart'),
+	Promise = require('es6-promise').Promise;
 
 describe('MultipartUpload', function() {
 

--- a/test/spec/read.js
+++ b/test/spec/read.js
@@ -4,7 +4,7 @@
 var _ = require('lodash'),
 	crypto = require('crypto'),
 	S3ReadStream = require('read'),
-	Stream = require('stream'),
+	Stream = require('readable-stream'),
 	EventEmitter = require('events').EventEmitter;
 
 /*


### PR DESCRIPTION
Since we make use of the `cork` functionality in `streams3` and `Promise` in node 0.11 both need to be polyfilled for older versions of node. The two new libraries address both issues.

The oldest version of node, 0.8, includes an old verison of npm which cannot handle the "^" symbol in package.json dependencies; include workaround information for this scenario (upgrade to at least 1.4.6).

Updated CI to include the new node versions for testing and updated the documentation to reflect the new changes.

In tests, ensure the error event gets watched for before any writes occur (older versions of node emit `error` on the same tick).

Now included is a more sane way for handling a pseudo `_flush` handler. It turns out that if you use `expect` in an event from an event emitter, any exception you throw will be transparently captured and re-emitted as an error event; not necessarily what you want. try-catch blocks have been added for those cases to forward the error to the real handler.
