### PR TITLE
Primitive E-Tag support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 - '0.10'
 - '0.8'
 before_install:
-  - npm install -g "npm@>=1.4.6"
+- npm install -g "npm@>=1.4.6"
 after_success:
 - npm install coveralls
 - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # s3-streams
 
-> Support for streaming reads and writes from and to S3 using Amazon's native API.
+Support for streaming reads and writes from and to S3 using Amazon's native API.
 
-![build status](http://img.shields.io/travis/izaakschroeder/s3-streams.svg?style=flat)
-![coverage](http://img.shields.io/coveralls/izaakschroeder/s3-streams.svg?style=flat)
+![build status](http://img.shields.io/travis/izaakschroeder/s3-streams/master.svg?style=flat)
+![coverage](http://img.shields.io/coveralls/izaakschroeder/s3-streams/master.svg?style=flat)
 ![license](http://img.shields.io/npm/l/s3-streams.svg?style=flat)
 ![version](http://img.shields.io/npm/v/s3-streams.svg?style=flat)
 ![downloads](http://img.shields.io/npm/dm/s3-streams.svg?style=flat)
@@ -15,6 +15,7 @@ IMPORTANT: This library uses the `streams3` API. In order to provide compatibili
 If you are using `node 0.8` you must ensure your version of `npm` is at least `1.4.6`.
 
 Features:
+ * Smart ETags,
  * Native read streams,
  * Native write streams,
  * Smart piping (piping between S3 objects incurs no local download).
@@ -43,6 +44,19 @@ var download = S3S.ReadStream(new S3(), {
 	Bucket: 'my-bucket',
 	Key: 'my-key',
 	// Any other AWS SDK options
+});
+```
+
+Use sane ETags:
+```javascript
+var crypto = require('crypto'),
+    S3 = require('aws-sdk').S3,
+	S3S = require('s3-streams');
+
+var download = S3S.ReadStream(new S3(), {
+	Bucket: 'my-bucket',
+	Key: 'my-key',
+	ETag: crypto.createHash('sha1')
 });
 ```
 

--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -5,6 +5,16 @@ var _ = require('lodash'),
 	crypto = require('crypto'),
 	Promise = require('bluebird');
 
+// TODO: Eventually support the same kind of multipart E-Tags that S3 does?
+// See: http://stackoverflow.com/questions/12186993
+// Basically the problem is that if a large upload fails and you wish to resume
+// it, you resume on the part boundary instead of re-uploading the whole file.
+// However, to get the correct has, you have to rewind the file from the very
+// beginning. AWS E-Tags sidestep this by just using the E-Tags from all the
+// collected parts. If uploading large files it may be wise to calculate the
+// E-Tag first anyway, so you can verify the content hasn't changed when you
+// redo the upload (à la Content-MD5).
+
 /**
  * @constructor
  * @param {AWS.S3} s3 Instance.
@@ -34,6 +44,17 @@ function MultipartUpload(s3, options) {
 	this.options = options;
 	this.upload = this.create();
 	this.parts = [ ];
+
+	if (!_.has(options, 'ETag')) {
+		this.eTag = crypto.createHash('md5');
+	} else if (_.isString(options.ETag)) {
+		this.eTag = {
+			update: _.noop,
+			digest: _.constant(options.ETag)
+		};
+	} else {
+		this.eTag = options.ETag;
+	}
 }
 
 /**
@@ -79,6 +100,12 @@ MultipartUpload.prototype.uploadPart = function uploadPart(data) {
 	var self = this,
 		partNumber = this.parts.length + 1;
 
+	if (!Buffer.isBuffer(data)) {
+		return Promise.reject(new TypeError('Must pass buffer.'));
+	}
+
+	this.eTag.update(data);
+
 	var part = this.upload.then(function afterUpload(uploadId) {
 		return new Promise(function partPromise(resolve, reject) {
 			var s3Part = {
@@ -122,6 +149,7 @@ MultipartUpload.prototype.finish = function finish() {
 				self.s3.completeMultipartUpload({
 					Bucket: self.options.Bucket,
 					Key: self.options.Key,
+					ETag: self.eTag.digest('hex'),
 					UploadId: uploadId,
 					MultipartUpload: {
 						Parts: parts


### PR DESCRIPTION
Allow for use of fixed string E-Tags or E-Tags generated from the data sent through the stream. The API for building the E-Tag exactly matches node's `crypto` hash API so that it is easy to use functions from that family.

The new options object looks something like:

```javascript
{
	ETag: crypto.createHash('sha1')
}
```

The default value is to use an MD5 hash, which matches Amazon's default behavior in the general case (though they use something different for multipart uploads). Perhaps in the future support will be added to match their esoteric E-Tag default, but this behavior is more consistent and predictable so it's what we're sticking with. Amazon's choice may have been influenced by the desire to resume uploads later and not have to recalculate the hash from the beginning of the file; not only does that use case not apply here (yet?) but recalcuating the hash from the start of the file is desirable anyway since it ensures file integrity.