### PR TITLE
Check for existence of cb() before calling it

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -70,7 +70,9 @@ S3WriteStream.prototype.end = function end(data, encoding, cb) {
 		}).catch(function errored(err) {
 			// We failed; emulate how the writable triggers errors
 			self._writableState.errorEmitted = true;
-			cb(err);
+			if (_.isFunction(cb)) {
+				cb(err);
+			}
 			self.emit('error', err);
 		});
 	}

--- a/test/spec/write.js
+++ b/test/spec/write.js
@@ -167,5 +167,22 @@ describe('S3WriteStream', function() {
 				});
 			});
 		});
+
+		it('should deal with errors without a callback specified', function(done) {
+			var spy = sinon.spy();
+			this.stream.upload.finish.returns(Promise.reject('errorz'));
+			this.stream.once('error', spy);
+			this.stream.on('error', function(err) {
+				try {
+					expect(err).to.equal('errorz');
+					expect(spy).to.be.calledOnce;
+					done();
+				} catch (e) {
+					done(e);
+				}
+			});
+
+			this.stream.end();
+		});
 	});
 });


### PR DESCRIPTION
Otherwise we'll throw a TypeError and never find out what the actual error was. The issue I was seeing:

    Unhandled rejection TypeError: undefined is not a function

Where the actual error should've been:

    UnexpectedParameter: Unexpected key 'ETag' found in params