### PR TITLE
Omit ETag from parameters if no ETag given

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -45,9 +45,7 @@ function MultipartUpload(s3, options) {
 	this.upload = this.create();
 	this.parts = [ ];
 
-	if (!_.has(options, 'ETag')) {
-		this.eTag = crypto.createHash('md5');
-	} else if (_.isString(options.ETag)) {
+	if (_.isString(options.ETag)) {
 		this.eTag = {
 			update: _.noop,
 			digest: _.constant(options.ETag)
@@ -104,7 +102,9 @@ MultipartUpload.prototype.uploadPart = function uploadPart(data) {
 		return Promise.reject(new TypeError('Must pass buffer.'));
 	}
 
-	this.eTag.update(data);
+	if (self.eTag) {
+		self.eTag.update(data);
+	}
 
 	var part = this.upload.then(function afterUpload(uploadId) {
 		return new Promise(function partPromise(resolve, reject) {
@@ -146,15 +146,20 @@ MultipartUpload.prototype.finish = function finish() {
 	return self.upload.then(function afterUpload(uploadId) {
 		return Promise.all(self.parts).then(function afterParts(parts) {
 			return new Promise(function multipartPromise(resolve, reject) {
-				self.s3.completeMultipartUpload({
+				var s3Options = {
 					Bucket: self.options.Bucket,
 					Key: self.options.Key,
-					ETag: self.eTag.digest('hex'),
 					UploadId: uploadId,
 					MultipartUpload: {
 						Parts: parts
 					}
-				}, function multipartComplete(err, result) {
+				};
+
+				if (self.eTag) {
+					s3Options.ETag = self.eTag.digest('hex');
+				}
+
+				self.s3.completeMultipartUpload(s3Options, function multipartComplete(err, result) {
 					return err ? reject(err) : resolve(result);
 				});
 			});


### PR DESCRIPTION
This change will omit `ETag` from the parameters sent to S3 if none were passed in.

This should resolve #8.