### PR TITLE
Smart piping for HTTP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,15 @@ If you are using `node 0.8` you must ensure your version of `npm` is at least `1
 Features:
  * Native read streams,
  * Native write streams,
- * Smart piping (piping between S3 objects incurs no local download).
+ * Smart piping.
+
+## Usage
+
+```sh
+npm install s3-streams
+```
+
+### Write Streams
 
 Create streams for uploading to S3:
 ```javascript
@@ -34,6 +42,8 @@ var upload = S3S.WriteStream(new S3(), {
 });
 ```
 
+### Read Streams
+
 Create streams for downloading from S3:
 ```javascript
 var S3 = require('aws-sdk').S3,
@@ -44,6 +54,22 @@ var download = S3S.ReadStream(new S3(), {
 	Key: 'my-key',
 	// Any other AWS SDK options
 });
+```
+
+### Smart Piping
+
+Smart pipe files over HTTP:
+
+```javascript
+var http = require('http'),
+    S3 = require('aws-sdk').S3,
+	S3S = require('s3-streams');
+
+http.createServer(function(req, res) {
+    var src = S3S.ReadStream(...);
+    // Automatically sets the correct HTTP headers
+    src.pipe(res);
+})
 ```
 
 Smart pipe files on S3:
@@ -57,6 +83,8 @@ var src = S3S.ReadStream(...),
 // No data ever gets downloaded locally.
 src.pipe(dst);
 ```
+
+### Extras
 
 You can create streams with different settings by creating a partial for the specific S3 instance you have:
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -89,6 +89,26 @@ S3ReadStream.prototype.request = function request() {
 };
 
 /**
+ * Same as normal pipe with a few extra goodies packed in.
+ * @param {Object} target Target stream to pipe to.
+ * @param {Object} options Settings for the pipe.
+ * @param {Boolean} options.smart Change pipe behavior based on target.
+ * @returns {Object} Inner stream.
+ */
+S3ReadStream.prototype.pipe = function pipe(target, options) {
+	options = _.assign({
+		smart: true
+	}, options);
+	if (options.smart && _.has(target, 'setHeader')) {
+		this.once('open', function opened(file) {
+			target.setHeader('Content-Type', file.ContentType);
+			target.setHeader('Content-Length', file.ContentLength);
+		});
+	}
+	return Stream.Readable.prototype.pipe.apply(this, arguments);
+};
+
+/**
  * @param {Number} size Amount of data to read.
  * @returns {Undefined} Nothing.
  * @see Stream.Readable._read


### PR DESCRIPTION
Override `.pipe` to make it somewhat smarter when sending data to HTTP streams by automatically piping the header information as well. This feature is on by default, but can be turned off using a second parameter to `.pipe` à la `.pipe(target, { smart: false })`. This will also pave the way to do smart piping for S3 (zero download copy).

Docs and specs have also been updated for smart piping.

See: https://github.com/izaakschroeder/s3-streams/issues/13

/cc @GeoffreyPlitt