### PR TITLE
Added broader support to read functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,18 @@ var download = S3S.ReadStream(new S3(), {
 ```
 
 ### Smart Piping
-Smart piping automatically forwards headers returned from the S3 service directly to your pipe destination if it has `setHeader` function. 
+Smart piping automatically forwards headers returned from the S3 service directly to your pipe destination if it has `setHeader` function.
 
 The headers option has two potential models:
 - Array: If headers is an array, it will forward any header values that are present on the S3 response.
-- Truthy: If it is any other truthy value, only, two headers will be sent ('Content-Type' and 'Content-Length'). 
+- Truthy: If it is any other truthy value, only, two headers will be sent ('Content-Type' and 'Content-Length').
 
 Smart pipe files over HTTP:
 
 ```javascript
 var http = require('http'),
     S3 = require('aws-sdk').S3,
-	S3S = require('s3-streams'),
+    S3S = require('s3-streams'),
     opts = {
         headers: ['content-type', 'content-length', 'content-range']
     };
@@ -86,7 +86,7 @@ var S3 = require('aws-sdk').S3,
 	S3S = require('s3-streams');
 
 var src = S3S.ReadStream(...),
-	dst = S3S.WriteStream(...),
+    dst = S3S.WriteStream(...),
     opts = {
         headers: true // send 'content-type', 'content-length' if truthy
     };

--- a/README.md
+++ b/README.md
@@ -57,18 +57,26 @@ var download = S3S.ReadStream(new S3(), {
 ```
 
 ### Smart Piping
+Smart piping automatically forwards headers returned from the S3 service directly to your pipe destination if it has `setHeader` function. 
+
+The headers option has two potential models:
+- Array: If headers is an array, it will forward any header values that are present on the S3 response.
+- Truthy: If it is any other truthy value, only, two headers will be sent ('Content-Type' and 'Content-Length'). 
 
 Smart pipe files over HTTP:
 
 ```javascript
 var http = require('http'),
     S3 = require('aws-sdk').S3,
-	S3S = require('s3-streams');
+	S3S = require('s3-streams'),
+    opts = {
+        headers: ['content-type', 'content-length', 'content-range']
+    };
 
 http.createServer(function(req, res) {
     var src = S3S.ReadStream(...);
     // Automatically sets the correct HTTP headers
-    src.pipe(res);
+    src.pipe(res, opts);
 })
 ```
 
@@ -78,10 +86,13 @@ var S3 = require('aws-sdk').S3,
 	S3S = require('s3-streams');
 
 var src = S3S.ReadStream(...),
-	dst = S3S.WriteStream(...);
+	dst = S3S.WriteStream(...),
+    opts = {
+        headers: true // send 'content-type', 'content-length' if truthy
+    };
 
 // No data ever gets downloaded locally.
-src.pipe(dst);
+src.pipe(dst, opts);
 ```
 
 ### Extras

--- a/lib/read.js
+++ b/lib/read.js
@@ -93,24 +93,23 @@ S3ReadStream.prototype.request = function request() {
  * Same as normal pipe with a few extra goodies packed in.
  * @param {Object} target Target stream to pipe to.
  * @param {Object} options Settings for the pipe.
- * @param {Boolean} options.smart Change pipe behavior based on target.
+ * @param {Array} options.headers Change pipe behavior based on target.
  * @returns {Object} Inner stream.
  */
 S3ReadStream.prototype.pipe = function pipe(target, options) {
 	options = _.assign({
-		headers: true
+		headers: options ? options.smart : true
 	}, options);
-	if (options.headers && _.isFunction(target.setHeader)) {
 
-		this.once('open', function opened(file) {
-			if ( !_.isArray(options.headers) ) {
-				target.setHeader('Content-Type', file.ContentType);
-				target.setHeader('Content-Length', file.ContentLength);
+	if (options.headers && _.isFunction(target.setHeader)) {
+		this.once('open', function opened(data) {
+			if (!_.isArray(options.headers)) {
+				target.setHeader('Content-Type', data.ContentType);
+				target.setHeader('Content-Length', data.ContentLength);
 			} else {
-				var headers = file.Headers;
-				options.headers.forEach(function setHeader(headerName) {
-					if ( _.has(headers, headerName) ) {
-						target.setHeader(headerName, headers[headerName]);
+				_.each(options.headers, function setHeader(headerName) {
+					if (_.has(data.Headers, headerName)) {
+						target.setHeader(headerName, data.Headers[headerName]);
 					}
 				});
 			}

--- a/lib/read.js
+++ b/lib/read.js
@@ -46,8 +46,6 @@ S3ReadStream.prototype.request = function request() {
 	var self = this;
 	this.req = this.client.getObject(_.assign({ }, this.options));
 	this.stream = this.req.on('httpHeaders', function httpHeaders(statusCode, headers) {
-		console.log('----headers are here', headers, '-----');
-
 		// Broadcast any errors.
 		if (statusCode >= 300) {
 			self.emit('error', { statusCode: statusCode });

--- a/lib/read.js
+++ b/lib/read.js
@@ -46,6 +46,7 @@ S3ReadStream.prototype.request = function request() {
 	var self = this;
 	this.req = this.client.getObject(_.assign({ }, this.options));
 	this.stream = this.req.on('httpHeaders', function httpHeaders(statusCode, headers) {
+		console.log('----headers are here', headers, '-----');
 
 		// Broadcast any errors.
 		if (statusCode >= 300) {
@@ -101,7 +102,7 @@ S3ReadStream.prototype.pipe = function pipe(target, options) {
 	options = _.assign({
 		headers: true
 	}, options);
-	if (options.headers && _.has(target, 'setHeader')) {
+	if (options.headers && _.isFunction(target.setHeader)) {
 
 		this.once('open', function opened(file) {
 			if ( !_.isArray(options.headers) ) {

--- a/lib/read.js
+++ b/lib/read.js
@@ -69,6 +69,8 @@ S3ReadStream.prototype.request = function request() {
 			ContentType: headers['content-type'],
 			Bucket: self.options.Bucket,
 			Key: self.options.Key,
+			Headers: headers,
+			StatusCode: statusCode,
 			Body: self
 		});
 	}).createReadStream().on('end', function end() {
@@ -97,12 +99,22 @@ S3ReadStream.prototype.request = function request() {
  */
 S3ReadStream.prototype.pipe = function pipe(target, options) {
 	options = _.assign({
-		smart: true
+		headers: true
 	}, options);
-	if (options.smart && _.has(target, 'setHeader')) {
+	if (options.headers && _.has(target, 'setHeader')) {
+
 		this.once('open', function opened(file) {
-			target.setHeader('Content-Type', file.ContentType);
-			target.setHeader('Content-Length', file.ContentLength);
+			if ( !_.isArray(options.headers) ) {
+				target.setHeader('Content-Type', file.ContentType);
+				target.setHeader('Content-Length', file.ContentLength);
+			} else {
+				var headers = file.Headers;
+				options.headers.forEach(function setHeader(headerName) {
+					if ( _.has(headers, headerName) ) {
+						target.setHeader(headerName, headers[headerName]);
+					}
+				});
+			}
 		});
 	}
 	return Stream.Readable.prototype.pipe.apply(this, arguments);

--- a/test/spec/read.js
+++ b/test/spec/read.js
@@ -231,6 +231,16 @@ describe('S3ReadStream', function() {
 				});
 				expect(target.setHeader).to.not.beCalled;
 			});
+			it('should do nothing in legacy mode (smart:false)', function() {
+				source.pipe(target, { smart: false });
+				// Since target is fake, yank the stream ourselves
+				source.read(0);
+				this.request.emit('httpHeaders', 200, {
+					'content-length': 5,
+					'content-type': 'ab'
+				});
+				expect(target.setHeader).to.not.beCalled;
+			});
 		});
 
 	});


### PR DESCRIPTION
We wanted to use this library to request partial content from S3. In order for those requests to properly return we needed better access to getting and setting the S3 headers along with getting success HTTP Status codes besides 200 (i.e. 206 - Partial Content).
