### PR TITLE
WIP: Fix deadlock happens if a big file is uploaded

### DIFF
--- a/lib/write.js
+++ b/lib/write.js
@@ -141,7 +141,7 @@ S3WriteStream.prototype._part = function _part(buffer, callback) {
  * @see Stream.Writable._writev
  */
 S3WriteStream.prototype._writev = function _writev(buffers, callback) {
-	var chunks = _.pluck(buffers, 'chunk'),
+	var chunks = _.map(buffers, 'chunk'),
 		data = Buffer.concat(chunks, this._writableState.length);
 	return this._part(data, callback);
 };

--- a/lib/write.js
+++ b/lib/write.js
@@ -100,20 +100,32 @@ S3WriteStream.prototype.end = function end(data, encoding, cb) {
  * @returns {Undefined} Nothing.
  * @see Stream.Writable.write
  */
-S3WriteStream.prototype.write = function write() {
+S3WriteStream.prototype.write = function write(chunk, encoding, cb) {
+
+	if (typeof encoding === 'function') {
+	  cb = encoding;
+	  encoding = null;
+	}
+	if (typeof cb !== 'function') cb = function() {};
+	if (this._writableState.length + chunk.length >= S3WriteStream.lowWaterMark && !this._writableState.writing) {
+        var old_cb = cb;
+        cb = () => {
+            if (this._writableState.length && this._writableState.needDrain)
+                this.emit('drain');
+            old_cb();
+        };
+    }
 	// Write normally; since we're corked this isn't going to
 	// do anything other than add data to the buffer.
-	var result = Stream.Writable.prototype.write.apply(this, arguments);
-
+	var result = Stream.Writable.prototype.write.call(this, chunk, encoding, cb);
 	// Check to see if we've past the upload threshold and if
 	// so `uncork` so we can batch write everything at once. Since
 	// `uncork` automatically invokes the underlying write, we can
 	// safely call `cork` again immediately to go back to buffering.
 	if (this._writableState.length >= S3WriteStream.lowWaterMark) {
 		this.uncork();
-		this.cork();
+        this.cork();
 	}
-
 	return result;
 };
 


### PR DESCRIPTION
in the write stream, the stream uncork happens before the actual write method ends, and so the data doesn't get written completely. When this happen, the drain event doesn't get fired and so who ever writes to the stream waits indefnitely for the drain event.
The fix was to move the uncork, cork calls to the callback of the stream.write method